### PR TITLE
#163727226 Feature admin delete party

### DIFF
--- a/app/api/v1/blueprints/parties.py
+++ b/app/api/v1/blueprints/parties.py
@@ -87,3 +87,20 @@ def update_party(party_id):
         'status': 400,
         'data':[]
     }
+
+@party_blueprint.route('/parties/<int:party_id>', methods=['DELETE'])
+def delete_party(party_id):
+    result = politico.delete_party(party_id)
+    if result == 'Party deleted':
+        response = {
+            'status': 200,
+            'data':[]
+        }
+        response['data'].append({
+            'message': 'Party deleted successfully'
+        })
+        return jsonify(response), 200
+    response = {
+        'status': 400,
+        'data':[]
+    }

--- a/app/api/v1/politico.py
+++ b/app/api/v1/politico.py
@@ -69,3 +69,10 @@ class Politico(object):
             return 'Party not found'
         party.name = name
         return party
+    
+    def delete_party(self, party_id):
+        party = self.get_party_by_id(party_id)
+        if party == 'Not found':
+            return 'Party not found'
+        self.registered_parties.remove(party)
+        return 'Party deleted'

--- a/app/tests/v1/test_parties.py
+++ b/app/tests/v1/test_parties.py
@@ -52,3 +52,16 @@ def test_update_party(client):
     json_data = response.get_json()
     assert response.status_code == 200
     assert type(json_data['data']) == list
+
+def test_delete_party(client):
+    test_utils.register_user(client, 'admin')
+    login_res = test_utils.login_user(client, 'admin')
+    headers = {
+        'Authorization': 'Bearer {0}'.format(login_res.get_json()['data'][0]['auth_token'])
+    }
+    client.post('api/v1/parties', json=test_utils.PARTIES[0], headers=headers)
+    response =client.delete('api/v1/parties/1', headers=headers)
+    json_data = response.get_json()
+    assert response.status_code == 200
+    assert type(json_data['data']) == list
+    assert json_data['data'][0]['message'] == 'Party deleted successfully'


### PR DESCRIPTION
#### What does this PR do?
Create the admin delete party endpoint
#### Description of Task to be completed?
Have the following endpoint working
- DELETE /api/v1/parties/<party-id>
#### How should this be manually tested?
- Clone this repo in your computer
- Create and activate the virtual environment
`virutualenv venv`
- Install requirements
`pip install -r requirements.txt`
- Run application
`python run`
- Test the above endpoint using postman.
#### What are the relevant pivotal tracker stories?
[#163727226](https://www.pivotaltracker.com/story/show/163727226)
#### Screenshots
![admin-delete-party](https://user-images.githubusercontent.com/13434949/52459030-dbc70f00-2b73-11e9-9b89-72fca5b67051.png)
